### PR TITLE
Only add the webpack-plugin for client-side builds

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -6,8 +6,10 @@ exports.onCreateBabelConfig = ({ actions }, pluginOptions) => {
   });
 };
 
-exports.onCreateWebpackConfig = ({ actions }) => {
-  actions.setWebpackConfig({
-    plugins: [new VanillaExtractPlugin()],
-  });
+exports.onCreateWebpackConfig = ({ actions, stage }) => {
+  if (stage === "develop" || stage === "build-javascript") {
+    actions.setWebpackConfig({
+      plugins: [new VanillaExtractPlugin()],
+    });
+  }
 };


### PR DESCRIPTION
Hey 👋 , Thanks for making the plugin 😄 

Nothing broken but thought I'd suggest only creating the CSS files in the client-side JS builds. The webpack plugin isn't required for creating the class names. 
