### PR TITLE
Allow passing of options to VanillaExtractPlugin

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -6,10 +6,10 @@ exports.onCreateBabelConfig = ({ actions }, pluginOptions) => {
   });
 };
 
-exports.onCreateWebpackConfig = ({ actions, stage }) => {
+exports.onCreateWebpackConfig = ({ actions, stage }, {plugins, ...options}) => {
   if (stage === "develop" || stage === "build-javascript") {
     actions.setWebpackConfig({
-      plugins: [new VanillaExtractPlugin()],
+      plugins: [new VanillaExtractPlugin(options)],
     });
   }
 };


### PR DESCRIPTION
Hey @KyleAMathews, I'm pretty sure this is how it works? I've not don't much Gatsby plugin development before. 

This is mainly so I can pass `allowRuntime: true`